### PR TITLE
fix: terraform manifest

### DIFF
--- a/.github/workflows/continuous_release.yml
+++ b/.github/workflows/continuous_release.yml
@@ -29,11 +29,13 @@ jobs:
         run: make bump
         env:
           BUILD_VERSION: v${{ steps.gitversion.outputs.MajorMinorPatch }}-rc${{ steps.gitversion.outputs.CommitsSinceVersionSource }}
+          MAJOR_MINOR_PATCH: ${{ steps.gitversion.outputs.MajorMinorPatch }}
       - name: Bump Version for release
         if: startsWith(github.ref, 'refs/tags/v')
         run: make bump
         env:
           BUILD_VERSION: v${{ steps.gitversion.outputs.MajorMinorPatch }}
+          MAJOR_MINOR_PATCH: ${{ steps.gitversion.outputs.MajorMinorPatch }}
       - name: Commit Version Bump if on main
         if: github.ref == 'refs/heads/main'
         uses: EndBug/add-and-commit@v7

--- a/makefile
+++ b/makefile
@@ -30,7 +30,7 @@ ci: build lint format test
 
 bump:
 	sed -i -E "/^VERSION=/c\VERSION=$(BUILD_VERSION)" makefile
-	sed -i -E "/^  \"version\":/c\  \"version\": \"$(BUILD_VERSION)\"," terraform-registry-manifest.json
+	sed -i -E "/^  \"version\":/c\  \"version\": $(MAJOR_MINOR_PATCH)," terraform-registry-manifest.json
 
 release:
 	GOOS=darwin GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_darwin_amd64


### PR DESCRIPTION
Publishing to the Terraform registry was not working due to invalid `version` field in the manifest

Signed-off-by: Alexandre Gomez <gomez.a.corneille@gmail.com>