### PR TITLE
fix: terraform manifest

### DIFF
--- a/.github/workflows/continuous_release.yml
+++ b/.github/workflows/continuous_release.yml
@@ -40,7 +40,6 @@ jobs:
           echo "::set-output name=BuildVersion::$BUILD_VERSION"
         env:
           BUILD_VERSION: ${{ env.BUILD_VERSION }}
-          MAJOR_MINOR_PATCH: ${{ steps.gitversion.outputs.MajorMinorPatch }}
       - name: Checkout on main
         if: startsWith(github.ref, 'refs/tags/v')
         uses: actions/checkout@v3

--- a/makefile
+++ b/makefile
@@ -30,7 +30,6 @@ ci: build lint format test
 
 bump:
 	sed -i -E "/^VERSION=/c\VERSION=$(BUILD_VERSION)" makefile
-	sed -i -E "/^  \"version\":/c\  \"version\": \"$(MAJOR_MINOR_PATCH)\"," terraform-registry-manifest.json
 
 release:
 	GOOS=darwin GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_darwin_amd64

--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.15",
+  "version": 1,
   "metadata": {
     "protocol_versions": ["5.0"]
   }


### PR DESCRIPTION
It appears that the `version` field of the manifest is not related to the version of the provider

Signed-off-by: Alexandre Gomez <gomez.a.corneille@gmail.com>