### PR TITLE
fix: makefile versioning

### DIFF
--- a/.github/workflows/continuous_release.yml
+++ b/.github/workflows/continuous_release.yml
@@ -28,11 +28,11 @@ jobs:
       - name: Format version
         if: startsWith(github.ref, 'refs/heads/')
         run: |
-          echo "BUILD_VERSION=v${{ steps.gitversion.outputs.MajorMinorPatch }}-rc${{ steps.gitversion.outputs.CommitsSinceVersionSource }}" >> $GITHUB_ENV
+          echo "BUILD_VERSION=${{ steps.gitversion.outputs.MajorMinorPatch }}-rc${{ steps.gitversion.outputs.CommitsSinceVersionSource }}" >> $GITHUB_ENV
       - name: Format version fo release
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          echo "BUILD_VERSION=v${{ steps.gitversion.outputs.MajorMinorPatch }}" >> $GITHUB_ENV
+          echo "BUILD_VERSION=${{ steps.gitversion.outputs.MajorMinorPatch }}" >> $GITHUB_ENV
       - name: Bump Version
         id: bump_version
         run: |

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test:
 ci: build lint format test
 
 bump:
-	sed -i -E "/^VERSION=/c\VERSION=$(BUILD_VERSION)" makefile
+	sed -i -E "/^VERSION=/c\VERSION=$(BUILD_VERSION)" Makefile
 
 release:
 	GOOS=darwin GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_darwin_amd64


### PR DESCRIPTION
Renamed `makefile` into `Makefile` and removed prefix `v` for `VERSION` variable

Signed-off-by: Alexandre Gomez <gomez.a.corneille@gmail.com>