### PR TITLE
fix: continuous release commit version

### DIFF
--- a/.github/workflows/continuous_release.yml
+++ b/.github/workflows/continuous_release.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           default_author: github_actions
           message: "chore: [skip ci] bump version to ${{ steps.bump_version.outputs.BuildVersion }}"
+          push: "origin main --set-upstream"
   release:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: bump_version


### PR DESCRIPTION
The commit charged to bump the version for new releases was failing because it was trying to push on the tag. Forced the action to push on `main`

Signed-off-by: Alexandre Gomez <gomez.a.corneille@gmail.com>