### PR TITLE
fix: continuous release checkout

### DIFF
--- a/.github/workflows/continuous_release.yml
+++ b/.github/workflows/continuous_release.yml
@@ -59,6 +59,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          token: ${{ env.GITHUB_TOKEN }}
+          ref: "refs/heads/main"
       - name: Unshallow
         run: git fetch --prune --unshallow
       - name: Set up Go


### PR DESCRIPTION
Job `release` checkout on the version tag instead of `main` causing the release to have wrong version

Signed-off-by: Alexandre Gomez <gomez.a.corneille@gmail.com>