### PR TITLE
fix: bump commit author

### DIFF
--- a/.github/workflows/continuous_release.yml
+++ b/.github/workflows/continuous_release.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           commit_message: "chore: [skip ci] bump version to ${{ steps.bump_version.outputs.BuildVersion }}"
           commit_options: "-a"
+          commit_author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
   release:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: bump_version


### PR DESCRIPTION
Author of the bump commit was the user who triggered the bump. Now the author is always `github-actions[bot]`

Signed-off-by: Alexandre Gomez <gomez.a.corneille@gmail.com>