### PR TITLE
refactor: go release settings

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,10 +51,27 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
+  header: |
+    # Release {{ .Version }}
+
+    ## New Features
+
+    ## Bug Fixes
+
   extra_files:
     - glob: "terraform-registry-manifest.json"
       name_template: "{{ .ProjectName }}_{{ .Version }}_manifest.json"
   # If you want to manually examine the release before its live, uncomment this line:
-  # draft: true
+  draft: true
 changelog:
-  skip: true
+  use: github
+
+  groups:
+    - title: Features
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 0
+    - title: "Bug fixes"
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 1
+    - title: Others
+      order: 999


### PR DESCRIPTION
New release are now drafted with a template and publishing is manual.

Signed-off-by: Alexandre Gomez <gomez.a.corneille@gmail.com>